### PR TITLE
style: language picker style update

### DIFF
--- a/client/components/language-switcher.tsx
+++ b/client/components/language-switcher.tsx
@@ -1,34 +1,33 @@
-import { Button } from "@heroui/button";
-import { Dropdown, DropdownItem, DropdownMenu, DropdownTrigger } from "@heroui/dropdown";
+import { Button, ButtonGroup } from "@heroui/react";
 
 import { useIntl } from "@/contexts/IntlContext";
 
 const languages = [
-  { code: "sv", label: "Svenska" },
-  { code: "en", label: "English" },
-  { code: "de", label: "Deutsch" },
+  { code: "sv", label: "SWE 🇸🇪" },
+  { code: "en", label: "ENG 🇬🇧" },
+  { code: "de", label: "DEU 🇧🇪" },
 ] as const;
 
 export const LanguageSwitcher = () => {
   const { locale, setLocale } = useIntl();
 
-  const currentLanguage = languages.find((lang) => lang.code === locale) || languages[0];
-
   return (
-    <Dropdown>
-      <DropdownTrigger>
-        <Button variant="ghost" size="sm" color="primary">
-          {currentLanguage.label}
-        </Button>
-      </DropdownTrigger>
-      <DropdownMenu
-        aria-label="Language selection"
-        onAction={(key) => setLocale(key as "sv" | "en" | "de")}
-      >
-        {languages.map((lang) => (
-          <DropdownItem key={lang.code}>{lang.label}</DropdownItem>
-        ))}
-      </DropdownMenu>
-    </Dropdown>
+    <ButtonGroup aria-label="Language selection" variant="flat">
+      {languages.map((lang) => {
+        const isActive = locale === lang.code;
+
+        return (
+          <Button
+            key={lang.code}
+            aria-pressed={isActive}
+            className={isActive ? "font-bold" : undefined}
+            color={isActive ? "primary" : "default"}
+            onPress={() => setLocale(lang.code)}
+          >
+            {lang.label}
+          </Button>
+        );
+      })}
+    </ButtonGroup>
   );
 };

--- a/client/pages/settings/index.tsx
+++ b/client/pages/settings/index.tsx
@@ -1,3 +1,5 @@
+import { Card } from "@heroui/react";
+
 import { LanguageSwitcher } from "@/components/language-switcher";
 import { useTranslation } from "@/contexts";
 import DefaultLayout from "@/layouts/default";
@@ -7,14 +9,12 @@ export default function SettingsPage() {
 
   return (
     <DefaultLayout>
-      <div>
-        {
-          <label className="mb-1 block text-sm font-medium text-gray-700">
-            {t("settings.change_lang")}
-          </label>
-        }
-        <LanguageSwitcher />
-      </div>
+      <Card className="mx-auto max-w-lg p-4">
+        <div className="flex flex-col gap-2">
+          <h2 className="text-xl font-bold">{t("settings.title")}</h2>
+          <LanguageSwitcher />
+        </div>
+      </Card>
     </DefaultLayout>
   );
 }


### PR DESCRIPTION
## Summary

Redesign of settings page

## Changes (If applicable)

Language picker is now button group instead of dropdown

## Screenshots (if UI)
BEFORE:
<img width="428" height="270" alt="Screenshot 2026-02-22 at 16 09 51" src="https://github.com/user-attachments/assets/a94b2228-98e9-4330-b8d3-fb8852667e23" />
AFTER:
<img width="428" height="270" alt="Screenshot 2026-02-22 at 16 09 38" src="https://github.com/user-attachments/assets/3179946f-a12d-4c75-bd64-bfb1bf78347f" />


## Checklist

- [x] I swear I have run `npm run build`
