### PR TITLE
use default timezone

### DIFF
--- a/client/contexts/IntlContext.tsx
+++ b/client/contexts/IntlContext.tsx
@@ -29,6 +29,7 @@ const messages: Record<Locale, Messages> = {
 };
 
 const LOCALE_STORAGE_KEY = "preferred-locale";
+const DEFAULT_TIME_ZONE = "Europe/Stockholm";
 
 export const IntlProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const [locale, setLocaleState] = useState<Locale>("sv"); // Default to Swedish
@@ -57,6 +58,7 @@ export const IntlProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
         getMessageFallback={({ key }) => key}
         locale={locale}
         messages={messages[locale]}
+        timeZone={DEFAULT_TIME_ZONE}
         onError={(error) => {
           console.error(error);
         }}


### PR DESCRIPTION
## Summary

Adds Stockholm as default timeline to silence warning

## Features Added (If applicable)

-

## Changes (If applicable)

-

## Screenshots (if UI)

-

## Checklist

- [x] I swear I have run `npm run build`
