### PR TITLE
Prevent log file on server

### DIFF
--- a/server/src/utils/logger.ts
+++ b/server/src/utils/logger.ts
@@ -1,3 +1,5 @@
+import fs from "fs";
+import path from "path";
 import winston from "winston";
 
 interface CustomLogger extends winston.Logger {
@@ -10,22 +12,36 @@ interface CustomLogger extends winston.Logger {
 }
 
 const { combine, timestamp, printf, colorize } = winston.format;
+const isServerlessRuntime = process.env.VERCEL === "1";
 
 // Custom log format
 const myFormat = printf(({ level, message, timestamp }) => {
   return `${timestamp} [${level}]: ${message}`;
 });
 
+const transports: winston.transport[] = [new winston.transports.Console()];
+
+if (!isServerlessRuntime) {
+  const logDir = path.resolve(process.cwd(), "logs");
+
+  try {
+    fs.mkdirSync(logDir, { recursive: true });
+
+    transports.push(
+      new winston.transports.File({
+        filename: path.join(logDir, "combined.log"),
+        format: winston.format.uncolorize(),
+      }),
+    );
+  } catch (error) {
+    console.warn(`File logging disabled: ${(error as Error).message}`);
+  }
+}
+
 const logger = winston.createLogger({
   level: process.env.NODE_ENV === "production" ? "info" : "debug",
   format: combine(timestamp(), colorize(), myFormat),
-  transports: [
-    new winston.transports.Console(),
-    new winston.transports.File({
-      filename: "logs/combined.log",
-      format: winston.format.uncolorize(),
-    }),
-  ],
+  transports,
 }) as CustomLogger;
 
 logger.infoObject = function (obj: any, message?: string) {


### PR DESCRIPTION
## Summary

Server error when attempting to mkdir on VERCEL, logs are automatic

## Features Added (If applicable)

-

## Changes (If applicable)

-

## Screenshots (if UI)

-

## Checklist

- [x] I swear I have run `npm run build`
