### PR TITLE
add locale to dates

### DIFF
--- a/client/components/events/detail/EventDetailCard.tsx
+++ b/client/components/events/detail/EventDetailCard.tsx
@@ -9,30 +9,31 @@ import { addToast } from "@heroui/toast";
 import { IoClose } from "react-icons/io5";
 
 import { useAuth } from "@/contexts/AuthContext";
+import { useIntl } from "@/contexts/IntlContext";
 import { CSKEvent, CSKEventType, EventsService } from "@/lib/api-client";
 
 import { EventUserEntry, EventUserListAccordion } from "./EventUserListAccordion";
 
-const formatDate = (isoString?: string) => {
+const formatDate = (isoString: string | undefined, locale: string) => {
   if (!isoString) return "N/A";
   const date = new Date(isoString);
 
   if (Number.isNaN(date.getTime())) return "N/A";
 
-  return new Intl.DateTimeFormat("sv-SE", {
+  return new Intl.DateTimeFormat(locale, {
     weekday: "short",
     day: "numeric",
     month: "short",
   }).format(date);
 };
 
-const formatTime = (isoString?: string) => {
+const formatTime = (isoString: string | undefined, locale: string) => {
   if (!isoString) return "N/A";
   const date = new Date(isoString);
 
   if (Number.isNaN(date.getTime())) return "N/A";
 
-  return new Intl.DateTimeFormat("sv-SE", {
+  return new Intl.DateTimeFormat(locale, {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
@@ -54,6 +55,7 @@ const CSKEventTypeString: Record<CSKEventType, string> = {
 
 export default function EventDetailCard({ event }: EventDetailCardProps) {
   const { user } = useAuth();
+  const { locale } = useIntl();
 
   type AttendanceChoice = "yes" | "no" | undefined;
   const statusToChoice = (status?: string | null): AttendanceChoice =>
@@ -94,9 +96,9 @@ export default function EventDetailCard({ event }: EventDetailCardProps) {
   const eventName = event?.name ?? "Loading event...";
   const eventPlace = event?.place ?? "";
   const eventDescription = event?.description ?? "No description available.";
-  const eventDate = formatDate(event?.dateStart);
-  const eventStartTime = formatTime(event?.dateStart);
-  const eventEndTime = formatTime(event?.dateEnd);
+  const eventDate = formatDate(event?.dateStart, locale);
+  const eventStartTime = formatTime(event?.dateStart, locale);
+  const eventEndTime = formatTime(event?.dateEnd, locale);
   const eventTimeRange =
     eventEndTime !== "N/A" ? `${eventStartTime} - ${eventEndTime}` : eventStartTime;
   const registrationRequired = !!event?.requiresRegistration;

--- a/client/components/events/overview/EventListCard.tsx
+++ b/client/components/events/overview/EventListCard.tsx
@@ -1,7 +1,7 @@
 import { Card, CardBody, CardHeader } from "@heroui/card";
 import { Link } from "@heroui/link";
 
-import { useTranslation } from "@/contexts/IntlContext";
+import { useIntl } from "@/contexts/IntlContext";
 import { CSKEvent, CSKEventType } from "@/lib/apiClient";
 
 const eventTypeMeta: Record<CSKEventType, { label: string; color: string }> = {
@@ -13,22 +13,22 @@ const eventTypeMeta: Record<CSKEventType, { label: string; color: string }> = {
   OTHER: { label: "Annat", color: "bg-slate-200 text-slate-700" },
 };
 
-const formatDate = (isoDate: string) =>
-  new Intl.DateTimeFormat("sv-SE", {
+const formatDate = (isoDate: string, locale: string) =>
+  new Intl.DateTimeFormat(locale, {
     weekday: "short",
     month: "short",
     day: "numeric",
   }).format(new Date(isoDate));
 
-const formatTimeRange = (start: string, end?: string | null) => {
-  const from = new Intl.DateTimeFormat("sv-SE", {
+const formatTimeRange = (start: string, locale: string, end?: string | null) => {
+  const from = new Intl.DateTimeFormat(locale, {
     hour: "2-digit",
     minute: "2-digit",
   }).format(new Date(start));
 
   if (!end) return from;
 
-  const to = new Intl.DateTimeFormat("sv-SE", {
+  const to = new Intl.DateTimeFormat(locale, {
     hour: "2-digit",
     minute: "2-digit",
   }).format(new Date(end));
@@ -41,7 +41,7 @@ interface EventListCardProps {
 }
 
 export const EventListCard = ({ event }: EventListCardProps) => {
-  const { t } = useTranslation();
+  const { locale, t } = useIntl();
   const badge = eventTypeMeta[event.type] ?? eventTypeMeta.OTHER;
 
   return (
@@ -56,13 +56,15 @@ export const EventListCard = ({ event }: EventListCardProps) => {
             <span className="bg-default-100 text-default-500 rounded-full px-3 py-1 text-xs font-medium">
               {event.place}
             </span>
-            <div className="text-default-700 font-semibold">{formatDate(event.dateStart)}</div>
+            <div className="text-default-700 font-semibold">
+              {formatDate(event.dateStart, locale)}
+            </div>
           </div>
           <div className="text-default-500 flex w-full flex-wrap justify-between text-sm">
             <span className={`rounded-full px-3 py-1 text-xs font-semibold ${badge.color}`}>
               {badge.label}
             </span>
-            <div>{formatTimeRange(event.dateStart, event.dateEnd)}</div>
+            <div>{formatTimeRange(event.dateStart, locale, event.dateEnd)}</div>
           </div>
         </CardHeader>
         <CardBody className="gap-3">

--- a/client/components/events/overview/EventsListContent.tsx
+++ b/client/components/events/overview/EventsListContent.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useTranslation } from "@/contexts/IntlContext";
+import { useIntl } from "@/contexts/IntlContext";
 import { CSKEvent } from "@/lib/apiClient";
 
 import { EventsWeekSections } from "./EventsWeekSections";
@@ -16,7 +16,7 @@ const getIsoWeekNumber = (date: Date) => {
   return Math.ceil(((tempDate.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
 };
 
-const getWeekMeta = (isoDate: string) => {
+const getWeekMeta = (isoDate: string, locale: string) => {
   const eventDate = new Date(isoDate);
   const weekNumber = getIsoWeekNumber(eventDate);
 
@@ -32,7 +32,7 @@ const getWeekMeta = (isoDate: string) => {
   endOfWeek.setDate(startOfWeek.getDate() + 6);
   endOfWeek.setHours(23, 59, 59, 999);
 
-  const dayFormatter = new Intl.DateTimeFormat("sv-SE", { month: "short", day: "numeric" });
+  const dayFormatter = new Intl.DateTimeFormat(locale, { month: "short", day: "numeric" });
 
   return {
     key: `${startOfWeek.getFullYear()}-v${weekNumber}`,
@@ -46,7 +46,7 @@ interface EventsListContentProps {
 }
 
 export const EventsListContent = ({ events }: EventsListContentProps) => {
-  const { t } = useTranslation();
+  const { locale, t } = useIntl();
 
   const eventsGroupedByWeek = new Map<
     string,
@@ -54,7 +54,7 @@ export const EventsListContent = ({ events }: EventsListContentProps) => {
   >();
 
   events.forEach((event) => {
-    const weekMeta = getWeekMeta(event.dateStart);
+    const weekMeta = getWeekMeta(event.dateStart, locale);
     const existingWeekGroup = eventsGroupedByWeek.get(weekMeta.key);
 
     if (existingWeekGroup) {


### PR DESCRIPTION
## Summary

Date formatters now use locale to produce localized strings

## Checklist

- [x] 1. I swear I have rebased
- [x] 2. I swear I have run `npm run lint`
- [x] 3. I swear I have run `npm run build`
- [x] 4. I swear I have tested my solution, it works like a charm.
