### PR TITLE
(#71) fix dependency vulnerabilities

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7103,9 +7103,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.9.tgz",
-      "integrity": "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.10.tgz",
+      "integrity": "sha512-8mOPs1//5q/rlkNSPcCegA6hiHJYDmSLEI8aMH/CdSQJNWztHC9WHNam5zdQlfpTwB9Xp7IBEsHfV5LKMJGVAw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1403,13 +1403,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -1497,9 +1497,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3865,9 +3865,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@prisma/adapter-pg": "^7.2.0",
-        "@prisma/client": "^7.3.0",
+        "@prisma/client": "^7.4.2",
         "bcryptjs": "^2.4.3",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
@@ -37,7 +37,7 @@
         "jest": "^30.1.3",
         "nodemon": "^3.0.2",
         "openapi-typescript-codegen": "^0.30.0",
-        "prisma": "^7.3.0",
+        "prisma": "^7.4.2",
         "supertest": "^7.1.4",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.1",
@@ -1803,12 +1803,12 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.3.0.tgz",
-      "integrity": "sha512-FXBIxirqQfdC6b6HnNgxGmU7ydCPEPk7maHMOduJJfnTP+MuOGa15X4omjR/zpPUUpm8ef/mEFQjJudOGkXFcQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-ts2mu+cQHriAhSxngO3StcYubBGTWDtu/4juZhXCUKOwgh26l+s4KD3vT2kMUzFyrYnll9u/3qWrtzRv9CGWzA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/client-runtime-utils": "7.3.0"
+        "@prisma/client-runtime-utils": "7.4.2"
       },
       "engines": {
         "node": "^20.19 || ^22.12 || >=24.0"
@@ -1827,15 +1827,15 @@
       }
     },
     "node_modules/@prisma/client-runtime-utils": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.3.0.tgz",
-      "integrity": "sha512-dG/ceD9c+tnXATPk8G+USxxYM9E6UdMTnQeQ+1SZUDxTz7SgQcfxEqafqIQHcjdlcNK/pvmmLfSwAs3s2gYwUw==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client-runtime-utils/-/client-runtime-utils-7.4.2.tgz",
+      "integrity": "sha512-cID+rzOEb38VyMsx5LwJMEY4NGIrWCNpKu/0ImbeooQ2Px7TI+kOt7cm0NelxUzF2V41UVVXAmYjANZQtCu1/Q==",
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/config": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.3.0.tgz",
-      "integrity": "sha512-QyMV67+eXF7uMtKxTEeQqNu/Be7iH+3iDZOQZW5ttfbSwBamCSdwPszA0dum+Wx27I7anYTPLmRmMORKViSW1A==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-7.4.2.tgz",
+      "integrity": "sha512-CftBjWxav99lzY1Z4oDgomdb1gh9BJFAOmWF6P2v1xRfXqQb56DfBub+QKcERRdNoAzCb3HXy3Zii8Vb4AsXhg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1887,56 +1887,70 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.3.0.tgz",
-      "integrity": "sha512-cWRQoPDXPtR6stOWuWFZf9pHdQ/o8/QNWn0m0zByxf5Kd946Q875XdEJ52pEsX88vOiXUmjuPG3euw82mwQNMg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-7.4.2.tgz",
+      "integrity": "sha512-B+ZZhI4rXlzjVqRw/93AothEKOU5/x4oVyJFGo9RpHPnBwaPwk4Pi0Q4iGXipKxeXPs/dqljgNBjK0m8nocOJA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.3.0",
-        "@prisma/engines-version": "7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735",
-        "@prisma/fetch-engine": "7.3.0",
-        "@prisma/get-platform": "7.3.0"
+        "@prisma/debug": "7.4.2",
+        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+        "@prisma/fetch-engine": "7.4.2",
+        "@prisma/get-platform": "7.4.2"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735.tgz",
-      "integrity": "sha512-IH2va2ouUHihyiTTRW889LjKAl1CusZOvFfZxCDNpjSENt7g2ndFsK0vdIw/72v7+jCN6YgkHmdAP/BI7SDgyg==",
+      "version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919.tgz",
+      "integrity": "sha512-5FIKY3KoYQlBuZC2yc16EXfVRQ8HY+fLqgxkYfWCtKhRb3ajCRzP/rPeoSx11+NueJDANdh4hjY36mdmrTcGSg==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines/node_modules/@prisma/debug": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.2.tgz",
+      "integrity": "sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==",
       "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@prisma/engines/node_modules/@prisma/get-platform": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.3.0.tgz",
-      "integrity": "sha512-N7c6m4/I0Q6JYmWKP2RCD/sM9eWiyCPY98g5c0uEktObNSZnugW2U/PO+pwL0UaqzxqTXt7gTsYsb0FnMnJNbg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
+      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.3.0"
+        "@prisma/debug": "7.4.2"
       }
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.3.0.tgz",
-      "integrity": "sha512-Mm0F84JMqM9Vxk70pzfNpGJ1lE4hYjOeLMu7nOOD1i83nvp8MSAcFYBnHqLvEZiA6onUR+m8iYogtOY4oPO5lQ==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-7.4.2.tgz",
+      "integrity": "sha512-f/c/MwYpdJO7taLETU8rahEstLeXfYgQGlz5fycG7Fbmva3iPdzGmjiSWHeSWIgNnlXnelUdCJqyZnFocurZuA==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.3.0",
-        "@prisma/engines-version": "7.3.0-16.9d6ad21cbbceab97458517b147a6a09ff43aa735",
-        "@prisma/get-platform": "7.3.0"
+        "@prisma/debug": "7.4.2",
+        "@prisma/engines-version": "7.5.0-10.94a226be1cf2967af2541cca5529f0f7ba866919",
+        "@prisma/get-platform": "7.4.2"
       }
     },
+    "node_modules/@prisma/fetch-engine/node_modules/@prisma/debug": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-7.4.2.tgz",
+      "integrity": "sha512-aP7qzu+g/JnbF6U69LMwHoUkELiserKmWsE2shYuEpNUJ4GrtxBCvZwCyCBHFSH2kLTF2l1goBlBh4wuvRq62w==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@prisma/fetch-engine/node_modules/@prisma/get-platform": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.3.0.tgz",
-      "integrity": "sha512-N7c6m4/I0Q6JYmWKP2RCD/sM9eWiyCPY98g5c0uEktObNSZnugW2U/PO+pwL0UaqzxqTXt7gTsYsb0FnMnJNbg==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-7.4.2.tgz",
+      "integrity": "sha512-UTnChXRwiauzl/8wT4hhe7Xmixja9WE28oCnGpBtRejaHhvekx5kudr3R4Y9mLSA0kqGnAMeyTiKwDVMjaEVsw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/debug": "7.3.0"
+        "@prisma/debug": "7.4.2"
       }
     },
     "node_modules/@prisma/get-platform": {
@@ -3782,9 +3796,9 @@
       }
     },
     "node_modules/confbox": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.2.tgz",
-      "integrity": "sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
+      "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -6476,13 +6490,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -6711,9 +6725,9 @@
       }
     },
     "node_modules/nodemon/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -6780,9 +6794,9 @@
       }
     },
     "node_modules/nypm": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.4.tgz",
-      "integrity": "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
+      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -6798,9 +6812,9 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.0.tgz",
-      "integrity": "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
+      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -7341,16 +7355,16 @@
       }
     },
     "node_modules/prisma": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.3.0.tgz",
-      "integrity": "sha512-ApYSOLHfMN8WftJA+vL6XwAPOh/aZ0BgUyyKPwUFgjARmG6EBI9LzDPf6SWULQMSAxydV9qn5gLj037nPNlg2w==",
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-7.4.2.tgz",
+      "integrity": "sha512-2bP8Ruww3Q95Z2eH4Yqh4KAENRsj/SxbdknIVBfd6DmjPwmpsC4OVFMLOeHt6tM3Amh8ebjvstrUz3V/hOe1dA==",
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@prisma/config": "7.3.0",
+        "@prisma/config": "7.4.2",
         "@prisma/dev": "0.20.0",
-        "@prisma/engines": "7.3.0",
+        "@prisma/engines": "7.4.2",
         "@prisma/studio-core": "0.13.1",
         "mysql2": "3.15.3",
         "postgres": "3.4.7"
@@ -7431,9 +7445,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
-      "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -8402,9 +8416,9 @@
       }
     },
     "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@prisma/adapter-pg": "^7.2.0",
-    "@prisma/client": "^7.3.0",
+    "@prisma/client": "^7.4.2",
     "bcryptjs": "^2.4.3",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
@@ -31,8 +31,6 @@
     "zod": "^4.1.5"
   },
   "devDependencies": {
-    "chokidar-cli": "^3.0.0",
-    "concurrently": "^8.2.2",
     "@types/bcryptjs": "^2.4.6",
     "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.17",
@@ -41,14 +39,16 @@
     "@types/jsonwebtoken": "^9.0.5",
     "@types/node": "^20.19.13",
     "@types/pg": "^8.15.5",
+    "chokidar-cli": "^3.0.0",
+    "concurrently": "^8.2.2",
     "jest": "^30.1.3",
     "nodemon": "^3.0.2",
     "openapi-typescript-codegen": "^0.30.0",
-    "prisma": "^7.3.0",
+    "prisma": "^7.4.2",
     "supertest": "^7.1.4",
     "ts-jest": "^29.4.1",
-    "tsc-alias": "^1.8.10",
     "ts-node": "^10.9.1",
+    "tsc-alias": "^1.8.10",
     "tsconfig-paths": "^4.2.0",
     "tsx": "^4.21.0",
     "typescript": "^5.3.2"


### PR DESCRIPTION
## Summary

runs npm audit fix to clear up vulnerabilities automatically

only one server vulnerability remains
https://github.com/prisma/prisma/issues/29123

### Notice

Requires `npm install` in:

- Root!
- Client!
- Server!

## Checklist

- [ ] 1. I swear I have rebased
- [ ] 2. I swear I have run `npm run lint`
- [ ] 3. I swear I have run `npm run build`
- [ ] 4. I swear I have tested my solution, it works like a charm.
