### PR TITLE
#119 Remove gitlens as recommended extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "esbenp.prettier-vscode",
     "mhutchie.git-graph",
-    "eamodio.gitlens",
     "dbaeumer.vscode-eslint"
   ]
 }


### PR DESCRIPTION
## Summary

Liam gnäller på Gitlens som rekommenderad extension. Den är nu borttagen för att liam ska sluta gnälla

## Changes (If applicable)

- Gitlens removed from recommended extensions

### Notice

Requires `npm install` in:

- [ ] Root
- [ ] Client
- [ ] Server

## Checklist

- [x] 1. I swear I have rebased
- [x] 2. I swear I have run `npm run lint`
- [x] 3. I swear I have run `npm run build`
- [x] 4. I swear I have tested my solution, it works like a charm.
